### PR TITLE
Fix issue affecting test explorer

### DIFF
--- a/src/xUnit.UserContext/Abstractions/IUserContextTest.cs
+++ b/src/xUnit.UserContext/Abstractions/IUserContextTest.cs
@@ -1,0 +1,9 @@
+﻿using Xunit.UserContext.Configuration;
+
+namespace Xunit.UserContext
+{
+    internal interface IUserContextTest
+    {
+        UserContextSettings UserContext { get; }
+    }
+}

--- a/src/xUnit.UserContext/UserFactAttribute.cs
+++ b/src/xUnit.UserContext/UserFactAttribute.cs
@@ -6,7 +6,7 @@ using Xunit.UserContext.Configuration;
 namespace Xunit.UserContext
 {
     [XunitTestCaseDiscoverer("Xunit.UserContext.XunitExtensions.UserFactDiscoverer", "xUnit.UserContext")]
-    public sealed class UserFactAttribute : FactAttribute
+    public sealed class UserFactAttribute : FactAttribute, IUserContextTest
     {
         public UserFactAttribute(string userSecretsId, LogonType logonType = Default.Logon, bool displayNameOnTest = Default.DisplayName)
             => UserContext = new UserContextSettings(userSecretsId, logonType, displayNameOnTest);

--- a/src/xUnit.UserContext/UserTheoryAttribute.cs
+++ b/src/xUnit.UserContext/UserTheoryAttribute.cs
@@ -6,7 +6,7 @@ using Xunit.UserContext.Configuration;
 namespace Xunit.UserContext
 {
     [XunitTestCaseDiscoverer("Xunit.UserContext.XunitExtensions.UserTheoryDiscoverer", "xUnit.UserContext")]
-    public sealed class UserTheoryAttribute : TheoryAttribute
+    public sealed class UserTheoryAttribute : TheoryAttribute, IUserContextTest
     {
         public UserTheoryAttribute(string userSecretsId, LogonType logonType = Default.Logon, bool displayNameOnTest = Default.DisplayName)
             => UserContext = new UserContextSettings(userSecretsId, logonType, displayNameOnTest);

--- a/src/xUnit.UserContext/XunitExtensions/UserFactDiscoverer.cs
+++ b/src/xUnit.UserContext/XunitExtensions/UserFactDiscoverer.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
-using Xunit.UserContext.Configuration;
 
 namespace Xunit.UserContext.XunitExtensions
 {
@@ -19,14 +18,12 @@ namespace Xunit.UserContext.XunitExtensions
 
         public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
         {
-            var credentials = factAttribute.GetNamedArgument<UserContextSettings>(nameof(UserFactAttribute.UserContext));
-
             var defaultMethodDisplay = discoveryOptions.MethodDisplayOrDefault();
             var defaultMethodDisplayOptions = discoveryOptions.MethodDisplayOptionsOrDefault();
 
             return factDiscoverer.Discover(discoveryOptions, testMethod, factAttribute)
                      .Select(testCase =>
-                     new UserContextTestCase(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, credentials));
+                     new UserContextTestCase(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod));
         }
     }
 

--- a/src/xUnit.UserContext/XunitExtensions/UserTheoryDiscoverer.cs
+++ b/src/xUnit.UserContext/XunitExtensions/UserTheoryDiscoverer.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
-using Xunit.UserContext.Configuration;
 
 namespace Xunit.UserContext.XunitExtensions
 {
@@ -19,13 +18,11 @@ namespace Xunit.UserContext.XunitExtensions
 
         public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
         {
-            var credentials = factAttribute.GetNamedArgument<UserContextSettings>(nameof(UserTheoryAttribute.UserContext));
-
             var defaultMethodDisplay = discoveryOptions.MethodDisplayOrDefault();
             var defaultMethodDisplayOptions = discoveryOptions.MethodDisplayOptionsOrDefault();
 
             return theoryDiscoverer.Discover(discoveryOptions, testMethod, factAttribute)
-                                   .Select(testCase => new UserContextTestCase(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testCase.TestMethod, credentials, testCase.TestMethodArguments));
+                                   .Select(testCase => new UserContextTestCase(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testCase.TestMethod, testCase.TestMethodArguments));
         }
 
     }


### PR DESCRIPTION
Bug fix
 - fixed an issue where credentials were null on subsequent test runs if `Keep Test Execution Engine Running` was enabled in Visual Studio