### PR TITLE
Fix issue affecting tests when using full framework target

### DIFF
--- a/src/Xunit.UserContext.Tests/xUnit.UserContext.Tests.csproj
+++ b/src/Xunit.UserContext.Tests/xUnit.UserContext.Tests.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/xUnit.UserContext/xUnit.UserContext.csproj
+++ b/src/xUnit.UserContext/xUnit.UserContext.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Platforms>AnyCPU;x64</Platforms>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageLicenseUrl>https://github.com/kurtmkurtm/xUnit.UserContext/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/kurtmkurtm/xUnit.UserContext</PackageProjectUrl>
     <Description>xUnit.UserContext is an attribute based extension for xUnit that allows tests to run under the context of a given Windows user. Impersonation can be useful for running integration tests that use resources that require windows authentication, such as connecting to a database.</Description>

--- a/xUnit.UserContext.sln
+++ b/xUnit.UserContext.sln
@@ -10,27 +10,17 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{635FD86D-232D-4132-AC54-E6D0C4C71956}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{635FD86D-232D-4132-AC54-E6D0C4C71956}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{635FD86D-232D-4132-AC54-E6D0C4C71956}.Debug|x64.ActiveCfg = Debug|x64
-		{635FD86D-232D-4132-AC54-E6D0C4C71956}.Debug|x64.Build.0 = Debug|x64
 		{635FD86D-232D-4132-AC54-E6D0C4C71956}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{635FD86D-232D-4132-AC54-E6D0C4C71956}.Release|Any CPU.Build.0 = Release|Any CPU
-		{635FD86D-232D-4132-AC54-E6D0C4C71956}.Release|x64.ActiveCfg = Release|x64
-		{635FD86D-232D-4132-AC54-E6D0C4C71956}.Release|x64.Build.0 = Release|x64
 		{1271A6B2-1C57-42FD-A4E9-F9E86FF0CDA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1271A6B2-1C57-42FD-A4E9-F9E86FF0CDA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1271A6B2-1C57-42FD-A4E9-F9E86FF0CDA1}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{1271A6B2-1C57-42FD-A4E9-F9E86FF0CDA1}.Debug|x64.Build.0 = Debug|Any CPU
 		{1271A6B2-1C57-42FD-A4E9-F9E86FF0CDA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1271A6B2-1C57-42FD-A4E9-F9E86FF0CDA1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1271A6B2-1C57-42FD-A4E9-F9E86FF0CDA1}.Release|x64.ActiveCfg = Release|Any CPU
-		{1271A6B2-1C57-42FD-A4E9-F9E86FF0CDA1}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Bug fix
 - add .NET 4.6.1 framework target, and update test to run against it in addition to .NET Core 2.0
 - fixed an issue where dependencies weren't resolving correctly when running tests against full framework
 - clean-up, remove coverlet from test project (to be replaced with global tool in build pipeline) & remove unused x64 solution config